### PR TITLE
Inclusão do limarka em index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,11 @@
 </ul>
 
 <h1>
+<a id="limarka" class="anchor" href="#limarka" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Limarka</h1>
+
+<p>O <a href="https://github.com/abntex/limarka">limarka</a> é uma ferramenta que possibilita o usuário escrever o seu trabalho de conclusão de curso (monografia, dissertação ou teste) em Markdown. Ela converte o trabalho produzido em Markdown para LaTeX, utilizando um template baseado no modelo de trabalho acadêmico do abnTeX2, e produz PDFs em conformidade com as normas da ABNT.</p>
+
+<h1>
 <a id="apoio" class="anchor" href="#apoio" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Apoio</h1>
 
 <p>Este projeto agradece o apoio:</p>


### PR DESCRIPTION
A tentativa de incluir o limarka no README não funcionou pq o projeto utilizar o arquivo index.html para geração do site.

Não compreendi como a página inicial foi gerada, mas percebi que o arquivo `main.js` é responsável por atualizar a seção `nav` adicionando os links lá.

Adicionei o trecho baseando-se apenas em como as tags HTML foram geradas para as outras seções.

Eu iniciei o jerkyll localmente e funcionou como esperado:

![agora-vai-funcionar-com-o-limarka](https://cloud.githubusercontent.com/assets/3603111/21653380/8d35c9f6-d28f-11e6-8369-9bb5620ad668.png)
